### PR TITLE
[Won't Merge] Example code to show how to get composition string and candidate list from IMM32 API

### DIFF
--- a/ImeSharp.Demo/Form1.cs
+++ b/ImeSharp.Demo/Form1.cs
@@ -13,6 +13,9 @@ namespace ImeSharp.Demo
     public partial class Form1 : Form
     {
         private bool _inputMethodEnabled;
+        private TextCompositionEventArgs _compEvent;
+        private string inputContent = string.Empty;
+
         public Form1()
         {
             InitializeComponent();
@@ -23,11 +26,35 @@ namespace ImeSharp.Demo
             KeyDown += Form1_KeyDown;
 
             InputMethod.Initialize(this.Handle);
+            InputMethod.TextComposition += (o, e) =>
+            {
+                _compEvent = e;
+                UpdateUI();
+            };
+
+            InputMethod.TextInput += (o, e) =>
+            {
+                switch ((int)e.Result)
+                {
+                    case 8:
+                        if (inputContent.Length > 0)
+                            inputContent = inputContent.Remove(inputContent.Length - 1, 1);
+                        break;
+                    case 27:
+                    case 13:
+                        inputContent = "";
+                        break;
+                    default:
+                        inputContent += e.Result;
+                        break;
+                }
+
+                textBoxResult.Text = inputContent;
+            };
         }
 
         private void Application_Idle(object sender, EventArgs e)
         {
-            FakeDraw();
         }
 
         private void Form1_KeyDown(object sender, KeyEventArgs e)
@@ -40,8 +67,25 @@ namespace ImeSharp.Demo
             }
         }
 
-        private void FakeDraw()
+        private void UpdateUI()
         {
+            labelComp.Text = _compEvent.CompositionString;
+
+            if (_compEvent.CandidateList == null)
+            {
+                textBoxCandidates.Text = string.Empty;
+                return;
+            }
+
+            var candidatesList = string.Empty;
+            for (uint i = _compEvent.CandidatePageStart;
+                i < Math.Min(_compEvent.CandidatePageStart + _compEvent.CandidatePageSize, _compEvent.CandidateList.Length);
+                i++)
+            {
+                candidatesList += string.Format("{0}.{1}\r\n", i + 1 - _compEvent.CandidatePageStart, _compEvent.CandidateList[i]);
+            }
+
+            textBoxCandidates.Text = candidatesList;
         }
 
     }

--- a/ImeSharp/ImmCompositionResultHandler.cs
+++ b/ImeSharp/ImmCompositionResultHandler.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Text;
+using System.Runtime.InteropServices;
+using System.Collections;
+using System.Collections.Generic;
+using ImeSharp.Native;
+
+namespace ImeSharp
+{
+    internal abstract class ImmCompositionResultHandler
+    {
+        protected IntPtr _imeContext;
+
+        public int Flag { get; private set; }
+
+        internal ImmCompositionResultHandler(IntPtr imeContext, int flag)
+        {
+            this.Flag = flag;
+            _imeContext = imeContext;
+        }
+
+        internal virtual void Update() { }
+
+        internal bool Update(int lParam)
+        {
+            if ((lParam & Flag) == Flag)
+            {
+                Update();
+                return true;
+            }
+            return false;
+        }
+    }
+
+    internal class ImmCompositionString : ImmCompositionResultHandler, IEnumerable<byte>
+    {
+        private byte[] _values;
+
+        public int Length { get; private set; }
+
+        public byte[] Values { get { return _values; } }
+
+        public byte this[int index] { get { return _values[index]; } }
+
+        internal ImmCompositionString(IntPtr imeContext, int flag) : base(imeContext, flag)
+        {
+            Clear();
+        }
+
+        public IEnumerator<byte> GetEnumerator()
+        {
+            foreach (byte b in _values)
+                yield return b;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        public override string ToString()
+        {
+            if (Length <= 0)
+                return string.Empty;
+
+            return Encoding.Unicode.GetString(_values, 0, Length);
+        }
+
+        internal void Clear()
+        {
+            _values = new byte[0];
+            Length = 0;
+        }
+
+        internal override void Update()
+        {
+            Length = NativeMethods.ImmGetCompositionString(_imeContext, Flag, IntPtr.Zero, 0);
+            IntPtr pointer = Marshal.AllocHGlobal(Length);
+            try
+            {
+                NativeMethods.ImmGetCompositionString(_imeContext, Flag, pointer, Length);
+                _values = new byte[Length];
+                Marshal.Copy(pointer, _values, 0, Length);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(pointer);
+            }
+        }
+    }
+
+    internal class ImmCompositionInt : ImmCompositionResultHandler
+    {
+        public int Value { get; private set; }
+
+        internal ImmCompositionInt(IntPtr imeContext, int flag) : base(imeContext, flag) { }
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
+
+        internal override void Update()
+        {
+            Value = NativeMethods.ImmGetCompositionString(_imeContext, Flag, IntPtr.Zero, 0);
+        }
+    }
+}

--- a/ImeSharp/InputMethod.cs
+++ b/ImeSharp/InputMethod.cs
@@ -44,6 +44,33 @@ namespace ImeSharp
             set { _defaultTextStore = value; }
         }
 
+        public static bool ShowTextServiceUI;
+
+        private static ImmCompositionString _immCompositionString;
+        private static ImmCompositionInt _immCursorPosition;
+        public static string[] Candidates { get; private set; }
+
+        /// <summary>
+        /// First candidate index of current page
+        /// </summary>
+        public static uint CandidatesPageStart { get; private set; }
+
+        /// <summary>
+        /// How many candidates should display per page
+        /// </summary>
+        public static uint CandidatesPageSize { get; private set; }
+
+        /// <summary>
+        /// The selected canddiate index
+        /// </summary>
+        public static uint CandidatesSelection { get; private set; }
+
+        private static bool _compositionEnded;
+
+        public static bool IsTextInputActive { get; private set; }
+        public static event EventHandler<TextCompositionEventArgs> TextComposition;
+        public static event EventHandler<TextInputEventArgs> TextInput;
+
         /// <summary>
         /// Initialize InputMethod with a Window Handle.
         /// </summary>
@@ -57,6 +84,9 @@ namespace ImeSharp
 
             _prevWndProc = (IntPtr)NativeMethods.SetWindowLongPtr(_windowHandle, NativeMethods.GWL_WNDPROC,
                 Marshal.GetFunctionPointerForDelegate(_wndProcDelegate));
+
+            _immCompositionString = new ImmCompositionString(DefaultImc, NativeMethods.GCS_COMPSTR);
+            _immCursorPosition = new ImmCompositionInt(DefaultImc, NativeMethods.GCS_CURSORPOS);
         }
 
         /// <summary>
@@ -83,23 +113,8 @@ namespace ImeSharp
             return ((NativeMethods.IntPtrToInt32(hkl) & 0xf0000000) == 0xe0000000);
         }
 
-        public static void EnableOrDisableInputMethod(bool bEnabled)
+        public static void EnableOrDisableInputMethodIMM32(bool bEnabled)
         {
-            // InputMethod enable/disabled status was changed on the current focus Element.
-            if (TextServicesLoader.ServicesInstalled)
-            {
-                if (bEnabled)
-                {
-                    // Enabled. SetFocus to the default text store.
-                    TextServicesContext.Current.SetFocusOnDefaultTextStore();
-                }
-                else
-                {
-                    // Disabled. SetFocus to the empty dim.
-                    TextServicesContext.Current.SetFocusOnEmptyDim();
-                }
-            }
-
             //
             // Under IMM32 enabled system, we associate default hIMC or null hIMC.
             //
@@ -125,24 +140,181 @@ namespace ImeSharp
             }
         }
 
+        public static void EnableOrDisableInputMethodTSF(bool bEnabled)
+        {
+            // InputMethod enable/disabled status was changed on the current focus Element.
+            if (TextServicesLoader.ServicesInstalled)
+            {
+                if (bEnabled)
+                {
+                    // Enabled. SetFocus to the default text store.
+                    TextServicesContext.Current.SetFocusOnDefaultTextStore();
+                }
+                else
+                {
+                    // Disabled. SetFocus to the empty dim.
+                    TextServicesContext.Current.SetFocusOnEmptyDim();
+                }
+            }
+        }
+
+        public static void EnableOrDisableInputMethod(bool bEnabled)
+        {
+            IsTextInputActive = bEnabled;
+
+            EnableOrDisableInputMethodTSF(bEnabled);
+            EnableOrDisableInputMethodIMM32(bEnabled);
+        }
+
         private static IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
         {
-            IntPtr returnCode = NativeMethods.CallWindowProc(_prevWndProc, hWnd, msg, wParam, lParam);
-
             //TODO:
             switch (msg)
             {
-                case NativeMethods.WM_CHAR:
-                    break;
                 case NativeMethods.WM_KEYDOWN:
                     break;
                 case NativeMethods.WM_KEYUP:
+                    break;
+                case NativeMethods.WM_IME_SETCONTEXT:
+                    if ((int)wParam == 1)
+                    {
+                        if (!ShowTextServiceUI)
+                            lParam = IntPtr.Zero;
+                    }
+                    break;
+                case NativeMethods.WM_IME_NOTIFY:
+                    IMENotify((int)wParam);
+                    if (!ShowTextServiceUI)
+                        return IntPtr.Zero;
+                    break;
+                case NativeMethods.WM_IME_STARTCOMPOSITION:
+                    _compositionEnded = false;
+                    IMEStartComposion((int)lParam);
+                    if (!ShowTextServiceUI)
+                        return IntPtr.Zero;
+                    break;
+                case NativeMethods.WM_IME_COMPOSITION:
+                    IMEComposition((int)lParam);
+                    break;
+                case NativeMethods.WM_IME_ENDCOMPOSITION:
+                    _compositionEnded = true;
+                    IMEEndComposition((int)lParam);
+                    if (!ShowTextServiceUI)
+                        return IntPtr.Zero;
+                    break;
+                case NativeMethods.WM_CHAR:
+                    if (IsTextInputActive)
+                    {
+                        Console.WriteLine("WM_CHAR: {0}", (char)wParam.ToInt32());
+                        CharEvent((int)wParam);
+                    }
                     break;
                 default:
                     break;
             }
 
-            return returnCode;
+            return NativeMethods.CallWindowProc(_prevWndProc, hWnd, msg, wParam, lParam);
+        }
+        private static void IMEStartComposion(int lParam)
+        {
+            ClearComposition();
+        }
+
+        private static void IMEComposition(int lParam)
+        {
+            if (_immCompositionString.Update(lParam))
+            {
+                _immCursorPosition.Update();
+
+                if (TextComposition != null)
+                    TextComposition.Invoke(null, new TextCompositionEventArgs(
+                        _immCompositionString.ToString(), _immCursorPosition.Value,
+                        Candidates, CandidatesPageStart, CandidatesPageSize, CandidatesSelection));
+            }
+        }
+
+        private static void ClearComposition()
+        {
+            _immCompositionString.Clear();
+        }
+
+        private static void IMEEndComposition(int lParam)
+        {
+            ClearComposition();
+            IMECloseCandidate();
+
+            if (TextComposition != null)
+                TextComposition.Invoke(null, new TextCompositionEventArgs(null, 0));
+        }
+
+        private static void IMENotify(int WParam)
+        {
+            switch (WParam)
+            {
+                case NativeMethods.IMN_OPENCANDIDATE:
+                case NativeMethods.IMN_CHANGECANDIDATE:
+                    IMEChangeCandidate();
+                    break;
+                case NativeMethods.IMN_CLOSECANDIDATE:
+                    IMECloseCandidate();
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private static void IMEChangeCandidate()
+        {
+            if (_compositionEnded)
+                IMECloseCandidate();
+            else
+                UpdateCandidates();
+
+            if (TextComposition != null)
+                TextComposition.Invoke(null, new TextCompositionEventArgs(
+                    _immCompositionString.ToString(), _immCursorPosition.Value,
+                    Candidates, CandidatesPageStart, CandidatesPageSize, CandidatesSelection));
+        }
+
+        private static void UpdateCandidates()
+        {
+            uint length = NativeMethods.ImmGetCandidateList(DefaultImc, 0, IntPtr.Zero, 0);
+            if (length > 0)
+            {
+                IntPtr pointer = Marshal.AllocHGlobal((int)length);
+                length = NativeMethods.ImmGetCandidateList(DefaultImc, 0, pointer, length);
+                NativeMethods.CandidateList cList = (NativeMethods.CandidateList)Marshal.PtrToStructure(pointer, typeof(NativeMethods.CandidateList));
+
+                CandidatesSelection = cList.dwSelection;
+                CandidatesPageStart = cList.dwPageStart;
+                CandidatesPageSize = cList.dwPageSize;
+
+                if (cList.dwCount > 1)
+                {
+                    Candidates = new string[cList.dwCount];
+                    for (int i = 0; i < cList.dwCount; i++)
+                    {
+                        int sOffset = Marshal.ReadInt32(pointer, 24 + 4 * i);
+                        Candidates[i] = Marshal.PtrToStringUni(pointer + sOffset);
+                    }
+                }
+
+                Marshal.FreeHGlobal(pointer);
+            }
+            else
+                IMECloseCandidate();
+        }
+
+        private static void IMECloseCandidate()
+        {
+            CandidatesSelection = CandidatesPageStart = CandidatesPageSize = 0;
+            Candidates = null;
+        }
+
+        private static void CharEvent(int wParam)
+        {
+            if (TextInput != null)
+                TextInput.Invoke(null, new TextInputEventArgs((char)wParam));
         }
 
     }

--- a/ImeSharp/Native/NativeMethods.cs
+++ b/ImeSharp/Native/NativeMethods.cs
@@ -84,5 +84,8 @@ namespace ImeSharp.Native
 
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         public static extern IntPtr SendMessage(IntPtr hWnd, int Msg, int wParam, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        public static extern short VkKeyScanEx(char ch, IntPtr dwhkl);
     }
 }

--- a/ImeSharp/TextCompositionEventArgs.cs
+++ b/ImeSharp/TextCompositionEventArgs.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace ImeSharp
+{
+    /// <summary>
+    /// Arguments for the <see cref="IImmService.TextComposition" /> event.
+    /// </summary>
+    public struct TextCompositionEventArgs
+    {
+        public TextCompositionEventArgs(string compositionString, int cursorPosition,
+            string[] candidateList = null, uint candidatePageStart = 0, uint candidatePageSize = 0, uint candidateSelection = 0)
+        {
+            CompositionString = compositionString;
+            CursorPosition = cursorPosition;
+
+            CandidateList = candidateList;
+            CandidatePageStart = candidatePageStart;
+            CandidatePageSize = candidatePageSize;
+            CandidateSelection = candidateSelection;
+        }
+
+        /// <summary>
+        /// The full string as it's composed by the IMM.
+        /// </summary>    
+        public readonly string CompositionString;
+
+        /// <summary>
+        /// The position of the cursor inside the composed string.
+        /// </summary>    
+        public readonly int CursorPosition;
+
+        /// <summary>
+        /// The candidate text list for the composition.
+        /// This property is only supported on WindowsDX and WindowsUniversal.
+        /// If the composition string does not generate candidates this array is empty.
+        /// </summary>    
+        public readonly string[] CandidateList;
+
+        /// <summary>
+        /// First candidate index of current page.
+        /// </summary>
+        public readonly uint CandidatePageStart;
+
+        /// <summary>
+        /// How many candidates should display per page.
+        /// </summary>
+        public readonly uint CandidatePageSize;
+
+        /// <summary>
+        /// The selected candidate index.
+        /// </summary>
+        public readonly uint CandidateSelection;
+    }
+}

--- a/ImeSharp/TextInputEventArgs.cs
+++ b/ImeSharp/TextInputEventArgs.cs
@@ -1,0 +1,12 @@
+namespace ImeSharp
+{
+    public struct TextInputEventArgs
+    {
+        public TextInputEventArgs(char result)
+        {
+            Result = result;
+        }
+
+        public readonly char Result;
+    }
+}


### PR DESCRIPTION
This PR is just a example for reference.

I tested this PR with many IMEs, like Google PinYin, Sougou PinYin, Google PinYin. All of the IMEs won't work well if IMM32 was enabled by `InputMethod.EnableOrDisableInputMethodIMM32()`. And I found these IMEs are not IMM32-based, there are actually TSF-based. If you fetch composition string and result string from `TextCompositionManager`, it seems works fine.

So we may have to dig into the TSF side deeply. And we should enable IMM32 only when the active IME is IMM32-based.